### PR TITLE
wip: use customStyles to override the base layout

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,7 @@ postcss.config.js
 tailwind.config.js
 .editorconfig
 .github
+.vscode
+CHANGELOG.md
+CONTRIBUTING.md
+package-lock.json

--- a/src/banner/banner.js
+++ b/src/banner/banner.js
@@ -37,7 +37,7 @@ export default class Banner {
                 let secondaryLinkList = this.createSecondaryLinks(secondaryLinks)
                 secondaryElement = newElement('div', {
                     children: secondaryLinkList,
-                    classes: `${this.styling.linkWrapper} ${this.theme.linkWrapper}`
+                    classes: `${this.theme.linkWrapper} ${this.styling.linkWrapper} `
                 })
             } else {
                 secondaryElement = this.dismissibleButton()
@@ -45,10 +45,10 @@ export default class Banner {
 
             let badgeElement = null
             if (this.badge) {
-                badgeElement = newElement('span', { classes: `${this.styling.badge} ${this.theme.badge}` })
+                badgeElement = newElement('span', { classes: `${this.theme.badge} ${this.styling.badge}` })
                 badgeElement.innerText = this.badge
             }
-            let postLink = newElement('a', { classes: `${this.styling.postTitle} ${this.theme.postTitle}` })
+            let postLink = newElement('a', { classes: `${this.theme.postTitle} ${this.styling.postTitle}` })
 
             postLink.href = link
             postLink.innerText = title
@@ -64,12 +64,12 @@ export default class Banner {
             }
 
             let postElement = newElement('div', {
-                classes: `${this.styling.linkWrapper} ${this.theme.linkWrapper}`,
+                classes: `${this.theme.linkWrapper} ${this.styling.linkWrapper} `,
                 children: postChildren
             })
 
             let _hbar = newElement('div', {
-                classes: `${this.styling.wrapper} ${this.theme.wrapper}`,
+                classes: `${this.theme.wrapper} ${this.styling.wrapper} `,
                 children: [postElement, secondaryElement]
             })
 
@@ -134,7 +134,7 @@ export default class Banner {
         if (!secondaryLinks) return []
 
         return secondaryLinks.map(({ title, link }) => {
-            let style = `${this.styling.secondaryLink} ${this.theme.secondaryLink}`
+            let style = `${this.theme.secondaryLink} ${this.styling.secondaryLink} `
             let butter = newElement('a', { classes: style })
             butter.href = link
             butter.innerText = title

--- a/src/banner/banner.js
+++ b/src/banner/banner.js
@@ -7,12 +7,15 @@ export default class Banner {
      *
      * @param {object} param0
      */
-    constructor({ $el, dismissible, dismissFor, theme, badge }) {
+    constructor({ $el, dismissible, dismissFor, theme, badge, customStyles = null }) {
         this.$el = $el
         this.dismissible = dismissible
         this.dismissFor = dismissFor
         this.badge = badge
         this.theme = theme
+
+        // use the top level styling preferences
+        this.styling = customStyles != null ? customStyles : styling
     }
 
     /**
@@ -34,7 +37,7 @@ export default class Banner {
                 let secondaryLinkList = this.createSecondaryLinks(secondaryLinks)
                 secondaryElement = newElement('div', {
                     children: secondaryLinkList,
-                    classes: `${styling.linkWrapper} ${this.theme.linkWrapper}`
+                    classes: `${this.styling.linkWrapper} ${this.theme.linkWrapper}`
                 })
             } else {
                 secondaryElement = this.dismissibleButton()
@@ -42,10 +45,10 @@ export default class Banner {
 
             let badgeElement = null
             if (this.badge) {
-                badgeElement = newElement('span', { classes: `${styling.badge} ${this.theme.badge}` })
+                badgeElement = newElement('span', { classes: `${this.styling.badge} ${this.theme.badge}` })
                 badgeElement.innerText = this.badge
             }
-            let postLink = newElement('a', { classes: `${styling.postTitle} ${this.theme.postTitle}` })
+            let postLink = newElement('a', { classes: `${this.styling.postTitle} ${this.theme.postTitle}` })
 
             postLink.href = link
             postLink.innerText = title
@@ -61,12 +64,12 @@ export default class Banner {
             }
 
             let postElement = newElement('div', {
-                classes: `${styling.linkWrapper} ${this.theme.linkWrapper}`,
+                classes: `${this.styling.linkWrapper} ${this.theme.linkWrapper}`,
                 children: postChildren
             })
 
             let _hbar = newElement('div', {
-                classes: `${styling.wrapper} ${this.theme.wrapper}`,
+                classes: `${this.styling.wrapper} ${this.theme.wrapper}`,
                 children: [postElement, secondaryElement]
             })
 
@@ -131,7 +134,7 @@ export default class Banner {
         if (!secondaryLinks) return []
 
         return secondaryLinks.map(({ title, link }) => {
-            let style = `${styling.secondaryLink} ${this.theme.secondaryLink}`
+            let style = `${this.styling.secondaryLink} ${this.theme.secondaryLink}`
             let butter = newElement('a', { classes: style })
             butter.href = link
             butter.innerText = title

--- a/src/functions/init.js
+++ b/src/functions/init.js
@@ -1,4 +1,4 @@
-import { themes } from '../banner/styling';
+import { styling, themes } from '../banner/styling';
 import { config } from '../config/config'
 import { initNormalise } from "./normalise"
 
@@ -30,7 +30,13 @@ export function init(options = {}) {
     // if the user has dompurify installed. It can be optional
     configuration.DOMPurify = options.DOMPurify || null;
 
-    configuration.theme = themes[options.theme] || 'grey';
+    configuration.theme = themes[options.theme] || themes["gray"];
+
+    // load overrides for the styling section.
+    if (options.customStyles) {
+        configuration.customStyles = Object.assign(styling, options.customStyles)
+    }
+
     configuration.badge = options.badge || null;
 
     // we will default to false for configuration
@@ -51,6 +57,7 @@ export function init(options = {}) {
     if (typeof options.fetch == 'function') {
         configuration.fetch = options.fetch;
     }
+
     configuration.fetchOptions = config.fetchOptions;
     configuration.fetchOptions.headers = Object.assign(config.fetchOptions.headers, options.headers)
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /**
  * h-bar banner and dynamic announcement library
  *
- * @version 2.0.0
+ * @version 2.0.2
  * @license MIT
  * @copyright @ReeceM
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,6 +83,8 @@ export function getElementOptions(element) {
 /**
  * Determines if the banner has been dismissed.
  *
+ * @todo add option to check the hash on the stored value
+ *
  * @returns boolean
  */
 export function isDismissed() {


### PR DESCRIPTION
This fix restores the usage of the `customStyles` object key.

Although it should be noted somewhere that the styles it overrides are the base design of the parts, the theme and color is stilled used from the styling object.

This is where using a custom HTML template will work

Should close #34 